### PR TITLE
Updated plot scripts to use rqt_plot instead of rxplot

### DIFF
--- a/asctec_hl_interface/scripts/plot_acceleration
+++ b/asctec_hl_interface/scripts/plot_acceleration
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo " ### plotting acceleration x y z [m/s^2] ###"
-rxplot $1/fcu/imu/linear_acceleration/x:y:z -b 10
+rqt_plot $1/fcu/imu/linear_acceleration/x:y:z

--- a/asctec_hl_interface/scripts/plot_angular_velocity
+++ b/asctec_hl_interface/scripts/plot_angular_velocity
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo " ### plotting angular velocity roll pitch yaw [rad/s] ###"
-rxplot $1/fcu/imu/angular_velocity/x:y:z -b 10
+rqt_plot $1/fcu/imu/angular_velocity/x:y:z

--- a/asctec_hl_interface/scripts/plot_cmd
+++ b/asctec_hl_interface/scripts/plot_cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo " ### plotting x, y, z and yaw commands that arrived at the HLP ###"
-rxplot $1/fcu/debug/data[31]:data[32]:data[33]:data[34] -b 10 -l x,y,z,yaw -t "HLP commands"
+rqt_plot $1/fcu/debug/data[31]:data[32]:data[33]:data[34]

--- a/asctec_hl_interface/scripts/plot_ctrl_output
+++ b/asctec_hl_interface/scripts/plot_ctrl_output
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo " ### plotting output to LL controller, roll pitch yaw [rad] ###"
-rxplot $1/fcu/debug/data[0]:data[1]:data[2] -b 10 -l roll,pitch,yaw -t "HLP ctrl out"
+rqt_plot $1/fcu/debug/data[0]:data[1]:data[2]

--- a/asctec_hl_interface/scripts/plot_filter_bias
+++ b/asctec_hl_interface/scripts/plot_filter_bias
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo " ### plotting estimated acceleration sensor bias x, y, z [m/s^2] in body coordinates ###"
-rxplot $1/fcu/debug/data[16]:data[17]:data[18] -b 10
+rqt_plot $1/fcu/debug/data[16]:data[17]:data[18]

--- a/asctec_hl_interface/scripts/plot_filter_position
+++ b/asctec_hl_interface/scripts/plot_filter_position
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo " ### plotting position estimated by the luenberger oberserver x, y, z [m] in NED coordinates !!! ###"
-rxplot $1/fcu/debug/data[13]:data[14]:data[15] -b 10
+rqt_plot $1/fcu/debug/data[13]:data[14]:data[15]

--- a/asctec_hl_interface/scripts/plot_filter_velocity
+++ b/asctec_hl_interface/scripts/plot_filter_velocity
@@ -1,3 +1,4 @@
 #!/bin/bash
+
 echo " ### plotting velocity estimated by the luenberger observer x, y, z [m/s] in NED coordinates !!! ###"
-rxplot $1/fcu/debug/data[19]:data[20]:data[21] -b 10
+rqt_plot $1/fcu/debug/data[19]:data[20]:data[21]

--- a/asctec_hl_interface/scripts/plot_orientation
+++ b/asctec_hl_interface/scripts/plot_orientation
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo " ### plotting orientation qw qx qy qz ###"
-rxplot $1/fcu/imu/orientation/w:x:y:z -b 10
+rqt_plot $1/fcu/imu/orientation/w:x:y:z

--- a/asctec_hl_interface/scripts/plot_position_input
+++ b/asctec_hl_interface/scripts/plot_position_input
@@ -1,3 +1,4 @@
 #!/bin/bash
+
 echo " ### plotting  position input x, y, z [m] in NED coordinates !!! ###"
-rxplot $1/fcu/debug/data[22]:data[23]:data[3] -b 10
+rqt_plot $1/fcu/debug/data[22]:data[23]:data[3]

--- a/asctec_hl_interface/scripts/plot_rc
+++ b/asctec_hl_interface/scripts/plot_rc
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo " ### plotting rc channels ###"
-rxplot $1/fcu/rcdata/channel[0]:channel[1]:channel[2]:channel[3]:channel[4]:channel[5]:channel[6]:channel[7] -b 10
+rqt_plot $1/fcu/rcdata/channel[0]:channel[1]:channel[2]:channel[3]:channel[4]:channel[5]:channel[6]:channel[7]

--- a/asctec_hl_interface/scripts/plot_refmodel
+++ b/asctec_hl_interface/scripts/plot_refmodel
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo " ### plotting reference model x, y, z, v_x, v_y, v_z [m] / [m/s] ###"
-rxplot $1/fcu/debug/data[24]:data[25]:data[26]:data[35]:data[36]:data[37] -b 10
+rqt_plot $1/fcu/debug/data[24]:data[25]:data[26]:data[35]:data[36]:data[37]
 


### PR DESCRIPTION
These are the updated plot scripts to use `rqt_plot` instead of  `rxplot`. Also, `-b`, `-l` and `-t` options were removed as they don't seem to be supported by rqt_plot.