### PR TITLE
Service for wgs84-to-ENU coordinate conversion

### DIFF
--- a/asctec_hl_gps/CMakeLists.txt
+++ b/asctec_hl_gps/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(asctec_hl_gps)
 
-find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs asctec_hl_comm message_filters std_srvs)
+find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs asctec_hl_comm  message_filters std_srvs message_generation)
 
 find_package(cmake_modules REQUIRED)
 find_package(Eigen REQUIRED)
@@ -16,9 +16,12 @@ include_directories(${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${Eigen_INCLUDE_
 #  MinSizeRel     : w/o debug symbols, w/ optimization, stripped binaries
 set(CMAKE_BUILD_TYPE Release)
 
+add_service_files( FILES Wgs84ToEnu.srv )
+generate_messages()
+
 catkin_package(
     DEPENDS eigen
-    CATKIN_DEPENDS roscpp sensor_msgs asctec_hl_comm message_filters std_srvs 
+    CATKIN_DEPENDS roscpp sensor_msgs asctec_hl_comm message_filters std_srvs message_runtime
     INCLUDE_DIRS
     LIBRARIES # TODO
 )
@@ -30,5 +33,3 @@ target_link_libraries(gps_conversion ${catkin_LIBRARIES})
 add_executable(set_gps_reference src/set_gps_reference.cpp)
 add_dependencies(set_gps_reference ${catkin_EXPORTED_TARGETS})
 target_link_libraries(set_gps_reference ${catkin_LIBRARIES})
-
-

--- a/asctec_hl_gps/launch/gps_convert.launch
+++ b/asctec_hl_gps/launch/gps_convert.launch
@@ -1,0 +1,6 @@
+<launch>
+        <node name="gps_conv" pkg="asctec_hl_gps" type="gps_conversion" output="screen" clear_params="false">
+            <param name="use_pressure_height" value="true" />
+        </node>
+</launch>
+

--- a/asctec_hl_gps/launch/gps_set_ref.launch
+++ b/asctec_hl_gps/launch/gps_set_ref.launch
@@ -1,0 +1,6 @@
+<launch>
+<node name="set_gps_ref" pkg="asctec_hl_gps" type="set_gps_reference" output="screen" clear_params="false">
+            <remap from="gps" to="fcu/gps" />
+        </node>
+
+</launch>

--- a/asctec_hl_gps/package.xml
+++ b/asctec_hl_gps/package.xml
@@ -21,6 +21,7 @@
   <build_depend>message_filters</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>cmake_modules</build_depend>
+  <build_depend>message_generation</build_depend>
 
   <!-- Dependencies needed after this package is compiled. -->
   <run_depend>roscpp</run_depend>
@@ -28,6 +29,7 @@
   <run_depend>asctec_hl_comm</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>std_srvs</run_depend>
+  <run_depend>message_runtime</run_depend>
 
   <export>
 

--- a/asctec_hl_gps/src/gps_conversion.cpp
+++ b/asctec_hl_gps/src/gps_conversion.cpp
@@ -57,6 +57,9 @@ GpsConversion::GpsConversion() :
   gps_custom_pub_ = nh_.advertise<asctec_hl_comm::GpsCustomCartesian> ("fcu/gps_position_custom", 1);
   zero_height_srv_ = nh.advertiseService("set_height_zero", &GpsConversion::zeroHeightCb, this);
 
+  // Andrew Holliday's modification
+  gps_to_enu_srv_ = nh.advertiseService("gps_to_local_enu", &GpsConversion::wgs84ToEnuSrv, this);
+
   pnh.param("use_pressure_height", use_pressure_height_, false);
   ROS_INFO_STREAM("using height measurement from "<< (use_pressure_height_?"pressure sensor":"GPS"));
 
@@ -264,6 +267,16 @@ Eigen::Vector3d GpsConversion::ecefToEnu(const Eigen::Vector3d & ecef)
   return ecef_ref_orientation_ * (ecef - ecef_ref_point_);
 }
 
+bool GpsConversion::wgs84ToEnuSrv(asctec_hl_gps::Wgs84ToEnuRequest & wgs84Pt,
+                                  asctec_hl_gps::Wgs84ToEnuResponse & enuPt)
+{
+    geometry_msgs::Point tmp = wgs84ToEnu(wgs84Pt.lat, wgs84Pt.lon, wgs84Pt.alt);
+    enuPt.x = tmp.x;
+    enuPt.y = tmp.y;
+    enuPt.z = tmp.z;
+    return true;
+}
+    
 geometry_msgs::Point GpsConversion::wgs84ToEnu(const double & latitude, const double & longitude,
                                                const double & altitude)
 {

--- a/asctec_hl_gps/src/gps_conversion.h
+++ b/asctec_hl_gps/src/gps_conversion.h
@@ -22,6 +22,7 @@
 #include <asctec_hl_comm/GpsCustomCartesian.h>
 #include <std_srvs/Empty.h>
 #include <Eigen/Eigen>
+#include "asctec_hl_gps/Wgs84ToEnu.h"
 
 namespace asctec_hl_gps{
 
@@ -34,6 +35,7 @@ private:
   ros::Publisher gps_position_pub_;
   ros::Publisher gps_custom_pub_;
   ros::ServiceServer zero_height_srv_;
+  ros::ServiceServer gps_to_enu_srv_;
 
   message_filters::Subscriber<sensor_msgs::NavSatFix> gps_sub_sync_;
   message_filters::Subscriber<asctec_hl_comm::mav_imu> imu_sub_sync_;
@@ -66,6 +68,8 @@ private:
   void initReference(const double & latitude, const double & longitude, const double & altitude);
   Eigen::Vector3d wgs84ToEcef(const double & latitude, const double & longitude, const double & altitude);
   Eigen::Vector3d ecefToEnu(const Eigen::Vector3d & ecef);
+  bool wgs84ToEnuSrv(asctec_hl_gps::Wgs84ToEnuRequest & wgs84Pt,
+                     asctec_hl_gps::Wgs84ToEnuResponse & enuPt);
   geometry_msgs::Point wgs84ToEnu(const double & latitude, const double & longitude, const double & altitude);
   geometry_msgs::Point wgs84ToNwu(const double & latitude, const double & longitude, const double & altitude);
   bool zeroHeightCb(std_srvs::EmptyRequest & req, std_srvs::EmptyResponse & resp);

--- a/asctec_hl_gps/srv/Wgs84ToEnu.srv
+++ b/asctec_hl_gps/srv/Wgs84ToEnu.srv
@@ -1,0 +1,7 @@
+float64 lat
+float64 lon
+float64 alt
+---
+float64 x
+float64 y
+float64 z

--- a/asctec_hl_interface/fcu_parameters.yaml
+++ b/asctec_hl_interface/fcu_parameters.yaml
@@ -1,0 +1,16 @@
+fcu/serial_port:            /dev/ttyUSB0
+fcu/baudrate:               460800
+fcu/frame_id:               fcu
+fcu/packet_rate_imu:       50.0
+fcu/packet_rate_rc:         20.0
+fcu/packet_rate_gps:        5.0
+fcu/packet_rate_ssdk_debug: 10.0
+fcu/packet_rate_ekf_state:  0.0
+fcu/max_velocity_xy:        5.0
+fcu/max_velocity_z:         5.0
+fcu/packet_rate_mag:        100.0
+
+fcu/state_estimation:       HighLevel_SSDK
+fcu/position_control:       GPS
+
+


### PR DESCRIPTION
In implementing a GPS-waypoint-following system for the Pelican with the ETH firmware, we found it helpful to be able to convert a set of waypoints in wgs84 coordinates to ENU coordinates.  pelican_hl_gps's gps conversion node has code to do this.  To make this functionality available to our python node that reads in the waypoints, I altered the gps conversion node to provide a service that would take wgs84 coordinate as a request and give the equivalent ENU coordinate (based on the stored GPS reference point) as a response.

In principle it would have been possible to rewrite our code in C++ and simply include the gps code as a dependency, or find a way of calling the relevant function via some C++-to-Python interface, but this was the simplest solution.  It also seems likely that conversion from wgs84 to ENU coordinates may be a common use case for ROS systems working with the Pelican, so it made sense to me to make this functionality available over the ROS network.  Others might find this useful as well, so I'm creating this pull request.