### PR TITLE
Command-line argument to specify waypoint file

### DIFF
--- a/asctec_hl_interface/scripts/waypoint_nav
+++ b/asctec_hl_interface/scripts/waypoint_nav
@@ -39,6 +39,7 @@ import actionlib
 import re
 import time
 import sys
+import os
 
 import asctec_hl_comm.msg
 
@@ -122,6 +123,8 @@ if __name__ == '__main__':
     waypoint_file = "sampleways.txt"
     if len(sys.argv) > 1:
         waypoint_file = str(sys.argv[1])
+        if not os.path.isfile(waypoint_file) or not os.access(waypoint_file, os.R_OK):
+            sys.exit("%s is not a valid file or it is not readable" % waypoint_file)
     try:
         # Initializes a rospy node so that the SimpleActionClient can
         # publish and subscribe over ROS.

--- a/asctec_hl_interface/scripts/waypoint_nav
+++ b/asctec_hl_interface/scripts/waypoint_nav
@@ -38,13 +38,14 @@ import rospy
 import actionlib
 import re
 import time
+import sys
 
 import asctec_hl_comm.msg
 
-def parseWaypoints():
+def parseWaypoints(file):
     rospy.loginfo("parsing waypoint list...")
     # read file
-    text = open("sampleways.txt","r").readlines()
+    text = open(file,"r").readlines()
     waypoints = list();
 
     linecounter = 0
@@ -117,11 +118,15 @@ def feedback_cb(feedback):
     rospy.loginfo("MAV currently at: " + "\t" + str(feedback.current_pos.x) + "\t" + str(feedback.current_pos.y) + "\t" + str(feedback.current_pos.z))
 
 if __name__ == '__main__':
+    # Default sample waypoint file
+    waypoint_file = "sampleways.txt"
+    if len(sys.argv) > 1:
+        waypoint_file = str(sys.argv[1])
     try:
         # Initializes a rospy node so that the SimpleActionClient can
         # publish and subscribe over ROS.
         rospy.init_node('wpclient')
-        liste = parseWaypoints();
+        liste = parseWaypoints(waypoint_file);
         for line in liste:
             waypoint_client(line)
     except rospy.ROSInterruptException:


### PR DESCRIPTION
By default, `waypoint_nav` has a hard-coded reference to `sampleways.txt`. This quick fix allows it to receive the path of a waypoint file as its first command-line argument.