### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/asctec_hl_comm/CMakeLists.txt
+++ b/asctec_hl_comm/CMakeLists.txt
@@ -43,6 +43,9 @@ generate_messages(
   DEPENDENCIES geometry_msgs std_msgs sensor_msgs actionlib_msgs
 )
 
+# Include generated header files
+include_directories(include ${catkin_INCLUDE_DIRS})
+
 # TODO: fill in what other packages will need to use this package
 ## DEPENDS: system dependencies of this project that dependent projects also need
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need


### PR DESCRIPTION
Could not get the system to build using catkin build system.

Original Error:
```
In file included from /catkin_ws/src/firefly-interface/asctec_mav_framework/asctec_hl_gps/src/gps_conversion.cpp:32:0:
/catkin_ws/src/firefly-interface/asctec_mav_framework/asctec_hl_gps/src/gps_conversion.h:23:39: fatal error: asctec_hl_comm/Wgs84ToEnu.h: No such file or directory
 #include <asctec_hl_comm/Wgs84ToEnu.h>
                                       ^
compilation terminated.
In file included from /catkin_ws/src/firefly-interface/asctec_mav_framework/asctec_hl_gps/src/gps_conversion_node.cpp:33:0:
/catkin_ws/src/firefly-interface/asctec_mav_framework/asctec_hl_gps/src/gps_conversion.h:23:39: fatal error: asctec_hl_comm/Wgs84ToEnu.h: No such file or directory
 #include <asctec_hl_comm/Wgs84ToEnu.h>
                                       ^
compilation terminated.
```