### PR TITLE
fix invalid yaml

### DIFF
--- a/asctec_hl_interface/rosdoc.yaml
+++ b/asctec_hl_interface/rosdoc.yaml
@@ -1,4 +1,4 @@
 - builder: doxygen
-   name: C++ API
-   output_dir: c++
-   file_patterns: '*.c *.cpp *.h *.cc *.hh *.dox'
+  name: C++ API
+  output_dir: c++
+  file_patterns: '*.c *.cpp *.h *.cc *.hh *.dox'


### PR DESCRIPTION
Indentation in a yaml file is important.

The build farm only mentioned the problem in the output: `ERROR: unable to load rosdoc config file` (http://jenkins.ros.org/view/Idoc/job/doc-indigo-asctec_mav_framework/114/console)

We will look into making this warning more visible, e.g. by marking the build `unstable`.